### PR TITLE
Use the same jargon everywhere...

### DIFF
--- a/meeting-notes/2024/2024-01-29_skimage2-meeting.md
+++ b/meeting-notes/2024/2024-01-29_skimage2-meeting.md
@@ -47,7 +47,7 @@
 - Make as many [non-breaking changes](https://github.com/scikit-image/scikit-image/wiki/API-changes-for-skimage2#proposed-api-changes-doable-ahead-of-skimage2) as possible
   - **Note: There are not many releases left to complete deprecation cycles!**
 - Concretize breaking-changes
-  - e.g., which functions use automatic scaling?
+  - e.g., which functions use implicit rescaling?
 - Settle pending decisions
 - Make skimage2 folder to make it very easy to play around with
 
@@ -61,7 +61,7 @@
 
 - Every PR / change goes into a migration document
 
-### 2024-11, Release candiate with new API
+### 2024-11, Release candidate with new API
 
 - Release candidate: `scikit-image==0.25.0`
   - identical with previous `scikit-image==0.24.0`


### PR DESCRIPTION
I'm seeing 'value-range scaling' in recent agenda items. I remember learning/discovering a correct/clear usage of rescaling (~ normalizing) vs. converting (~ changing color spaces) right here, in the context of developing scikit-image.

@lagru @stefanv @matthew-brett I thought I would update 'automatic scaling' to 'implicit rescaling' to make it clear it's the same discussion as in [Why `preserve_range` is not enough](https://hackmd.io/hX8GftVsQcKfDa3NBXxQow).